### PR TITLE
Guild -> Server mass rename & other fixes

### DIFF
--- a/core/prefix.py
+++ b/core/prefix.py
@@ -1,4 +1,4 @@
-from modules.generator import _check_values_guild
+from modules.generator import _check_values_server
 from core.database import *
 import psycopg
 from psycopg_pool import ConnectionPool 
@@ -12,8 +12,8 @@ database_password = config["database_password"]
 database_username = config["database_username"]
 
 async def prefix(bot, message):
-	guild = message.guild
-	await _check_values_guild(guild)
-	server = await getServer(guild.id)
+	server = message.server
+	await _check_values_server(server)
+	server = await getServer(server.id)
 	prefix = server["server_prefix"]
 	return [prefix, "@Rayz ", "@Rayz", "Rayz ", "Rayz"]

--- a/modules/api.py
+++ b/modules/api.py
@@ -4,7 +4,7 @@ from modules.generator import _check_values
 from modules.generator import _check_inventory
 from modules.generator import _check_inventory_member
 from modules.generator import _check_values_member
-from modules.generator import _check_values_guild
+from modules.generator import _check_values_server
 from modules.generator import check_leaderboard
 from modules.generator import check_leaderboard_author
 from modules.generator import command_processed
@@ -29,7 +29,7 @@ class API(commands.Cog):
 	@commands.command()
 	async def activate(self, ctx, *, password: str=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		curr_time = time.time()
 		if author.bot:
 			return

--- a/modules/economy.py
+++ b/modules/economy.py
@@ -10,7 +10,7 @@ from modules.generator import _check_values
 from modules.generator import _check_inventory
 from modules.generator import _check_inventory_member
 from modules.generator import _check_values_member
-from modules.generator import _check_values_guild
+from modules.generator import _check_values_server
 from modules.generator import check_leaderboard
 from modules.generator import check_leaderboard_author
 from modules.generator import command_processed
@@ -35,8 +35,8 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def test_values(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
-		await _check_values_guild(guild)
+		server = ctx.server
+		await _check_values_server(server)
 		try:
 			users = await getAllUsers()
 			with db_connection.connection() as conn:
@@ -63,8 +63,8 @@ class Economy(commands.Cog):
 	#@commands.command()
 	#async def test_values(self, ctx):
 	#	author = ctx.author
-	#	guild = ctx.guild
-	#	await _check_values_guild(guild)
+	#	server = ctx.server
+	#	await _check_values_server(server)
 	#	try:
 	#		connection = psycopg2.connect(user=database_username, password=database_password, port=database_port, database=database_name)
 	#		async def getUser():
@@ -104,18 +104,18 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def purge_partners(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
-		await _check_values_guild(guild)
+		server = ctx.server
+		await _check_values_server(server)
 
 		economy_settings = fileIO("config/economy_settings.json", "load")
 		config = fileIO("config/config.json", "load")
 
-		support_guild = await self.bot.fetch_server(economy_settings["support_server_id"])
-		members_support_guild = await support_guild.fetch_members()
+		support_server = await self.bot.fetch_server(economy_settings["support_server_id"])
+		members_support_server = await support_server.fetch_members()
 
-		if author in members_support_guild:
-			author_support_guild = await support_guild.fetch_member(author.id)
-			roles_list = await author_support_guild.fetch_role_ids()
+		if author in members_support_server:
+			author_support_server = await support_server.fetch_member(author.id)
+			roles_list = await author_support_server.fetch_role_ids()
 			if config["developer_role_id"] in roles_list or config["manager_role_id"] in roles_list:
 				try:
 					with db_connection.connection() as conn:
@@ -141,8 +141,8 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def partners(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
-		await _check_values_guild(guild)
+		server = ctx.server
+		await _check_values_server(server)
 		try:
 			with db_connection.connection() as conn:
 				async def getServers():
@@ -155,9 +155,9 @@ class Economy(commands.Cog):
 				for i in servers:
 					if i["partner_status"].lower() == "true":
 						try:
-							get_guild = await self.bot.fetch_server(i["id"])
-							vanity_url = get_guild.vanity_url
-							partners_list.append("[{}]({}) `-` **x{}**".format(get_guild.name, vanity_url, i["economy_multiplier"]))
+							get_server = await self.bot.fetch_server(i["id"])
+							vanity_url = get_server.vanity_url
+							partners_list.append("[{}]({}) `-` **x{}**".format(get_server.name, vanity_url, i["economy_multiplier"]))
 						except:
 							pass
 				random.shuffle(partners_list)
@@ -176,8 +176,8 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def test1(self, ctx):
 		author = ctx.author
-		guild = await self.bot.fetch_server("Mldgz04R")
-		await _check_values_guild(guild)
+		server = await self.bot.fetch_server("Mldgz04R")
+		await _check_values_server(server)
 		roles_list = await author.fetch_role_ids()
 		boost_or_not = False
 		if 30053069 in roles_list:
@@ -190,8 +190,8 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def test(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
-		await _check_values_guild(guild)
+		server = ctx.server
+		await _check_values_server(server)
 		user = await getUser(author.id)
 		print(user)
 		if user["inventory"] == None or user["inventory"]["inventory"] == None:
@@ -202,11 +202,11 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def add(self, ctx, member: guilded.Member=None, *, amount: int=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		if author.bot:
 			return
 		DEV = fileIO("config/config.json", "load")
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		if not author.id in DEV["Developer"]:
 			return
 		try:
@@ -225,12 +225,12 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def e_ban(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		if author.bot:
 			return
 		DEV = fileIO("config/config.json", "load")
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		if not author.id in DEV["Developer"]:
 			return
 		LB = fileIO("config/economy_settings.json", "load")
@@ -249,30 +249,30 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def toggle_partner(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 
 		economy_settings = fileIO("config/economy_settings.json", "load")
 		config = fileIO("config/config.json", "load")
 
-		support_guild = await self.bot.fetch_server(economy_settings["support_server_id"])
-		members_support_guild = await support_guild.fetch_members()
+		support_server = await self.bot.fetch_server(economy_settings["support_server_id"])
+		members_support_server = await support_server.fetch_members()
 
-		if author in members_support_guild:
-			author_support_guild = await support_guild.fetch_member(author.id)
-			roles_list = await author_support_guild.fetch_role_ids()
+		if author in members_support_server:
+			author_support_server = await support_server.fetch_member(author.id)
+			roles_list = await author_support_server.fetch_role_ids()
 			if config["developer_role_id"] in roles_list or config["managermanager_role_id"] in roles_list:
 				try:
-					server = await getServer(guild.id)
+					server = await getServer(server.id)
 					int_check = 0
 					if server["partner_status"].lower() == "false":
 						em = guilded.Embed(title="Partner management", description="How much would you like to increase the economy boost by?", color=0x363942)
-						em.set_footer(text="Congrats to {} for becoming a partner!".format(guild.name))
+						em.set_footer(text="Congrats to {} for becoming a partner!".format(server.name))
 						await ctx.reply(embed=em)
 						def pred(m):
 							return m.message.author == message.author
@@ -288,10 +288,10 @@ class Economy(commands.Cog):
 						add_data = float(server["economy_multiplier"]) + add_value
 						with db_connection.connection() as conn:
 							cursor = conn.cursor()
-							cursor.execute(f"UPDATE servers SET partner_status = 'True' WHERE ID = '{guild.id}'")
-							cursor.execute(f"UPDATE servers SET economy_multiplier = '{add_data}' WHERE ID = '{guild.id}'")
+							cursor.execute(f"UPDATE servers SET partner_status = 'True' WHERE ID = '{server.id}'")
+							cursor.execute(f"UPDATE servers SET economy_multiplier = '{add_data}' WHERE ID = '{server.id}'")
 							conn.commit()
-						em = guilded.Embed(title="Woo hoo!".format(author.name), description="`-` {} is now partnered!\n`-` All partner benefits have been activated!".format(guild.name), color=0x363942)
+						em = guilded.Embed(title="Woo hoo!".format(author.name), description="`-` {} is now partnered!\n`-` All partner benefits have been activated!".format(server.name), color=0x363942)
 						em.set_footer(text="This servers currency multiplier has been set to x{}".format(add_data))
 						em.set_thumbnail(url="https://cdn.discordapp.com/attachments/546687295684870145/988278191678435378/guilded_image_4bd81f3a0067c6025ab935d019169b71.png")
 						await ctx.reply(embed=em)
@@ -299,10 +299,10 @@ class Economy(commands.Cog):
 						add_data = 1.0
 						with db_connection.connection() as conn:
 							cursor = conn.cursor()
-							cursor.execute(f"UPDATE servers SET partner_status = 'False' WHERE ID = '{guild.id}'")
-							cursor.execute(f"UPDATE servers SET economy_multiplier = '{add_data}' WHERE ID = '{guild.id}'")
+							cursor.execute(f"UPDATE servers SET partner_status = 'False' WHERE ID = '{server.id}'")
+							cursor.execute(f"UPDATE servers SET economy_multiplier = '{add_data}' WHERE ID = '{server.id}'")
 							conn.commit()
-						em = guilded.Embed(title="Uh oh!".format(author.name), description="`-` {} is now un-partnered.\n`-` All partner benefits have been revoked.".format(guild.name), color=0x363942)
+						em = guilded.Embed(title="Uh oh!".format(author.name), description="`-` {} is now un-partnered.\n`-` All partner benefits have been revoked.".format(server.name), color=0x363942)
 						em.set_footer(text="This servers currency multiplier has been set to x{}".format(add_data))
 						await ctx.reply(embed=em)
 				except psycopg.DatabaseError as e:
@@ -312,12 +312,12 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def prices(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await check_leaderboard_author(author)
 		await _check_inventory(author)
@@ -347,12 +347,12 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def sell(self, ctx, *, item: str=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await check_leaderboard_author(author)
 		await _check_inventory(author)
@@ -420,11 +420,11 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def give(self, ctx, item: str=None, amount: int=None, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await check_leaderboard_author(author)
 		await _check_inventory(author)
@@ -508,8 +508,8 @@ class Economy(commands.Cog):
 						em = guilded.Embed(title="Transfer complete", description="`-` {:,} {} removed from <@{}>'s inventory.\n`-` <@{}> was given {:,} {}.".format(amount, item.lower(), author.id, member.id, amount, item.lower()), color=0x363942)
 						em.set_footer(text="All transfers are logged in order to keep track of alt account farming, which is against our Economy ToS.")
 						await ctx.reply(embed=em)
-						guild1 = await self.bot.fetch_server("Mldgz04R")
-						channel = await guild1.fetch_channel("22048e41-bcfc-49e9-a1fa-5b57171299bb")
+						server1 = await self.bot.fetch_server("Mldgz04R")
+						channel = await server1.fetch_channel("22048e41-bcfc-49e9-a1fa-5b57171299bb")
 						em = guilded.Embed(title="A transfer was made", description="{}[{}] gifted {}[{}] {:,} {}.".format(author.name, author.id, member.name, member.id, amount, item.lower()), color=0x363942)
 						await channel.send(embed=em)
 
@@ -541,8 +541,8 @@ class Economy(commands.Cog):
 						em = guilded.Embed(title="Transfer complete", description="`-` {:,} {} removed from <@{}>'s inventory.\n`-` <@{}> was given {:,} {}.".format(amount, item.lower(), author.id, member.id, amount, item.lower()), color=0x363942)
 						em.set_footer(text="All transfers are logged in order to keep track of alt account farming, which is against our Economy ToS.")
 						await ctx.reply(embed=em)
-						guild1 = await self.bot.fetch_server("Mldgz04R")
-						channel = await guild1.fetch_channel("22048e41-bcfc-49e9-a1fa-5b57171299bb")
+						server1 = await self.bot.fetch_server("Mldgz04R")
+						channel = await server1.fetch_channel("22048e41-bcfc-49e9-a1fa-5b57171299bb")
 						em = guilded.Embed(title="A transfer was made", description="{}[{}] gifted {}[{}] {:,} {}.".format(author.name, author.id, member.name, member.id, amount, item.lower()), color=0x363942)
 						await channel.send(embed=em)
 			else:
@@ -555,12 +555,12 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def gift(self, ctx, amount: int=None, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await check_leaderboard_author(author)
 		await _check_inventory(author)
@@ -587,7 +587,7 @@ class Economy(commands.Cog):
 		try:
 			user = await getUser(author.id)
 			member1 = await getUser(member.id)
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			prefix = server["server_prefix"]
 			if amount > user["pocket"]:
 				em = guilded.Embed(title="Uh oh!", description="`You don't have {:,} in your pocket.".format(amount), color=0x363942)
@@ -606,8 +606,8 @@ class Economy(commands.Cog):
 				em = guilded.Embed(title="Transfer complete", description="`-` {:,} {} removed from <@{}>'s pocket.\n`-` <@{}> was given {:,} {}.".format(amount, economy_settings["currency_name"], author.id, member.id, amount, economy_settings["currency_name"]), color=0x363942)
 				em.set_footer(text="All transfers are logged in order to keep track of alt account farming, which is against our Economy ToS.")
 				await ctx.reply(embed=em)
-				guild1 = await self.bot.fetch_server(economy_settings["support_server_id"])
-				channel = await guild1.fetch_channel("82204345-aa8d-487f-8808-17afc525a735")
+				server1 = await self.bot.fetch_server(economy_settings["support_server_id"])
+				channel = await server1.fetch_channel("82204345-aa8d-487f-8808-17afc525a735")
 				em = guilded.Embed(title="A transfer was made", description="{}[{}] gifted {}[{}] {:,} {}.".format(author.name, author.id, member.name, member.id, amount, economy_settings["currency_name"]), color=0x363942)
 				await channel.send(embed=em)
 		except psycopg.DatabaseError as e:
@@ -617,12 +617,12 @@ class Economy(commands.Cog):
 	@commands.command(aliases=["with"])
 	async def withdraw(self, ctx, amount: str=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await check_leaderboard_author(author)
 		await _check_inventory(author)
@@ -680,12 +680,12 @@ class Economy(commands.Cog):
 	@commands.command(aliases=["dep"])
 	async def deposit(self, ctx, amount: str=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await check_leaderboard_author(author)
 		await _check_inventory(author)
@@ -749,12 +749,12 @@ class Economy(commands.Cog):
 			page = 1
 
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await check_leaderboard_author(author)
 		await _check_inventory(author)
@@ -800,7 +800,7 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def rob(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if member == None:
 			em = guilded.Embed(title="Uh oh!", description="The member argument was left empty.\n\nEx: `{}rob <member>`".format(prefix), color=0x363942)
@@ -810,14 +810,14 @@ class Economy(commands.Cog):
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await check_leaderboard_author(author)
 		await _check_inventory(author)
 		await _check_inventory_member(member)
 		await command_processed(message, author)
 		try:
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			economy_settings = fileIO("config/economy_settings.json", "load")
 			LB_bans = fileIO("economy/bans.json", "load")
 			if author.id in LB_bans["bans"]:
@@ -892,34 +892,34 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def weekly(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await _check_inventory(author)
 		await command_processed(message, author)
 		economy_settings = fileIO("config/economy_settings.json", "load")
 		LB_bans = fileIO("economy/bans.json", "load")
-		support_guild = await self.bot.fetch_server(economy_settings["support_server_id"])
-		members_support_guild = await support_guild.fetch_members()
+		support_server = await self.bot.fetch_server(economy_settings["support_server_id"])
+		members_support_server = await support_server.fetch_members()
 		if author.id in LB_bans["bans"]:
 			em = guilded.Embed(title="Uh oh!", description="You were banned from Rayz's Economy for violating our ToS.", color=0x363942)
 			await ctx.reply(embed=em)
 			return
 		try:
 			user = await getUser(author.id)
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if user == None:
 				await _check_values(author)
 			gen_amount = random.randint(5000, 12000)
 			multiplier_amount = float(server["economy_multiplier"])
 			edit_message = None
-			if author in members_support_guild:
-				author_support_guild = await support_guild.fetch_member(author.id)
-				roles_list = await author_support_guild.fetch_role_ids()
+			if author in members_support_server:
+				author_support_server = await support_server.fetch_member(author.id)
+				roles_list = await author_support_server.fetch_role_ids()
 				if 30053086 in roles_list:
 					edit_message = ":Gold_tier: Elite supporter boosted you by `x3`"
 					multiplier_amount += 3
@@ -937,9 +937,9 @@ class Economy(commands.Cog):
 			curr_cooldown = 604800
 			delta = float(curr_time) - float(user["cooldowns"]["weekly_timeout"])
 			if delta >= curr_cooldown and delta>0:
-				if author in members_support_guild:
-					author_support_guild = await support_guild.fetch_member(author.id)
-					roles_list = await author_support_guild.fetch_role_ids()
+				if author in members_support_server:
+					author_support_server = await support_server.fetch_member(author.id)
+					roles_list = await author_support_server.fetch_role_ids()
 					if 30053086 in roles_list or 30053078 in roles_list or 30053069 in roles_list:
 						em = guilded.Embed(title="{} has obtained their weekly bonus.".format(author.name), description="<@{}> gained x{:,} {}!\n\n{}".format(author.id, gen_amount, economy_settings["currency_name"], edit_message), color=0x363942)
 					else:
@@ -973,12 +973,12 @@ class Economy(commands.Cog):
 	@commands.command()
 	async def slots(self, ctx, *, amount: int=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await _check_inventory(author)
 		await command_processed(message, author)
@@ -986,15 +986,15 @@ class Economy(commands.Cog):
 		LB_bans = fileIO("economy/bans.json", "load")
 		item_drops = fileIO("economy/drops.json", "load")
 		item_list = fileIO("economy/items.json", "load")
-		support_guild = await self.bot.fetch_server(economy_settings["support_server_id"])
-		members_support_guild = await support_guild.fetch_members()
+		support_server = await self.bot.fetch_server(economy_settings["support_server_id"])
+		members_support_server = await support_server.fetch_members()
 		if author.id in LB_bans["bans"]:
 			em = guilded.Embed(title="Uh oh!", description="You were banned from Rayz's Economy for violating our ToS.", color=0x363942)
 			await ctx.reply(embed=em)
 			return
 		try:
 			user = await getUser(author.id)
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			prefix = server["server_prefix"]
 
 			slots_bet_min = economy_settings["slots_bet_min"]
@@ -1150,10 +1150,10 @@ class Economy(commands.Cog):
 		if ctx.author.bot:
 			return
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await _check_inventory(author)
 		await command_processed(message, author)
@@ -1199,7 +1199,7 @@ class Economy(commands.Cog):
 			decrease_drop_slot_chance = economy_settings["dig_drop_slots_chance_decrease"]
 
 			user = await getUser(author.id)
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if user == None:
 				await _check_values(author)
 			curr_time = time.time()
@@ -1376,10 +1376,10 @@ class Economy(commands.Cog):
 		if ctx.author.bot:
 			return
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await _check_inventory(author)
 		await command_processed(message, author)
@@ -1395,8 +1395,8 @@ class Economy(commands.Cog):
 			item_drops = fileIO("economy/drops.json", "load")
 			item_list = fileIO("economy/items.json", "load")
 
-			support_guild = await self.bot.fetch_server(economy_settings["support_server_id"])
-			members_support_guild = await support_guild.fetch_members()
+			support_server = await self.bot.fetch_server(economy_settings["support_server_id"])
+			members_support_server = await support_server.fetch_members()
 
 			common_min = economy_settings["common_min"]
 			common_max = economy_settings["common_max"]
@@ -1436,7 +1436,7 @@ class Economy(commands.Cog):
 			decrease_drop_slot_chance = economy_settings["drop_slots_chance_decrease"]
 
 			user = await getUser(author.id)
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 
 			if user == None:
 				await _check_values(author)
@@ -1449,9 +1449,9 @@ class Economy(commands.Cog):
 			if delta >= curr_cooldown and delta>0:
 				message_list = []
 				booster_amount = 0
-				if author in members_support_guild:
-					author_support_guild = await support_guild.fetch_member(author.id)
-					roles_list = await author_support_guild.fetch_role_ids()
+				if author in members_support_server:
+					author_support_server = await support_server.fetch_member(author.id)
+					roles_list = await author_support_server.fetch_role_ids()
 					if tier_3_sub_role_id in roles_list:
 						booster_amount += tier_3_sub_boost_amount
 					elif tier_2_sub_role_id in roles_list:
@@ -1699,9 +1699,9 @@ class Economy(commands.Cog):
 				if not drops_lines_list == []:
 					message_list.append("__**Item drop:**__\n{}\n".format(" \n".join(drops_lines_list)))
 
-				if author in members_support_guild:
-					author_support_guild = await support_guild.fetch_member(author.id)
-					roles_list = await author_support_guild.fetch_role_ids()
+				if author in members_support_server:
+					author_support_server = await support_server.fetch_member(author.id)
+					roles_list = await author_support_server.fetch_role_ids()
 					if tier_3_sub_role_id in roles_list:
 						edit_message = ":Gold_tier: Elite supporter boosted you by `x{}`".format(tier_3_sub_boost_amount)
 						message_list.append(edit_message)
@@ -1743,12 +1743,12 @@ class Economy(commands.Cog):
 	@commands.command(aliases=["me", "bal", "balance"])
 	async def profile(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await check_leaderboard_author(author)
 		await _check_inventory(author)
@@ -1773,12 +1773,12 @@ class Economy(commands.Cog):
 	@commands.command(aliases=["inventory"])
 	async def inv(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await check_leaderboard_author(author)
 		await _check_inventory(author)
@@ -1792,7 +1792,7 @@ class Economy(commands.Cog):
 			return
 		try:
 			user = await getUser(author.id)
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			prefix = server["server_prefix"]
 			if user == None:
 				await _check_values(author)
@@ -1809,18 +1809,18 @@ class Economy(commands.Cog):
 			em = guilded.Embed(title="Uh oh!", description="Error. {}".format(e), color=0x363942)
 			await ctx.reply(embed=em)
 
-	#Get guild stats, is partner, and booster multiplier
+	#Get server stats, is partner, and booster multiplier
 	@commands.command()
 	async def stats(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		if author.bot:
 			return
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await command_processed(message, author)
-		server = await getServer(guild.id)
-		em = guilded.Embed(title="Guild stats:", description="**Partner:** {}\n**Multiplier:** x{}".format(server["partner_status"], server["economy_multiplier"]), color=0x363942)
+		server = await getServer(server.id)
+		em = guilded.Embed(title="Server stats:", description="**Partner:** {}\n**Multiplier:** x{}".format(server["partner_status"], server["economy_multiplier"]), color=0x363942)
 		await ctx.reply(embed=em)
 
 def setup(bot):

--- a/modules/fun.py
+++ b/modules/fun.py
@@ -18,7 +18,7 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def hug(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
 		action = "hug"
@@ -28,7 +28,7 @@ class Fun(commands.Cog):
 			return
 		matching = await match_check(ctx, member, action)
 		if not matching:
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if server["fun_module"] == "Disabled":
 				em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 				await message.reply(private=True, embed=em)
@@ -64,7 +64,7 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def kiss(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
 		action = "kiss"
@@ -73,7 +73,7 @@ class Fun(commands.Cog):
 			await ctx.send(embed=em)
 		matching = await match_check(ctx, member, action)
 		if not matching:
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if server["fun_module"] == "Disabled":
 				em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 				await message.reply(private=True, embed=em)
@@ -109,7 +109,7 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def feed(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
 		action = "feed"
@@ -118,7 +118,7 @@ class Fun(commands.Cog):
 			await ctx.send(embed=em)
 		matching = await match_check(ctx, member, action)
 		if not matching:
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if server["fun_module"] == "Disabled":
 				em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 				await message.reply(private=True, embed=em)
@@ -154,7 +154,7 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def tickle(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
 		action = "tickle"
@@ -163,7 +163,7 @@ class Fun(commands.Cog):
 			await ctx.send(embed=em)
 		matching = await match_check(ctx, member, action)
 		if not matching:
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if server["fun_module"] == "Disabled":
 				em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 				await message.reply(private=True, embed=em)
@@ -199,7 +199,7 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def pat(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
 		action = "pat"
@@ -208,7 +208,7 @@ class Fun(commands.Cog):
 			await ctx.send(embed=em)
 		matching = await match_check(ctx, member, action)
 		if not matching:
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if server["fun_module"] == "Disabled":
 				em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 				await message.reply(private=True, embed=em)
@@ -245,7 +245,7 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def slap(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
 		action = "slap"
@@ -254,7 +254,7 @@ class Fun(commands.Cog):
 			await ctx.send(embed=em)
 		matching = await match_check(ctx, member, action)
 		if not matching:
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if server["fun_module"] == "Disabled":
 				em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 				await message.reply(private=True, embed=em)
@@ -290,7 +290,7 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def holdhand(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
 		action = "holdhand"
@@ -299,7 +299,7 @@ class Fun(commands.Cog):
 			await ctx.send(embed=em)
 		matching = await match_check(ctx, member, action)
 		if not matching:
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if server["fun_module"] == "Disabled":
 				em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 				await message.reply(private=True, embed=em)
@@ -335,7 +335,7 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def highfive(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
 		action = "highfive"
@@ -344,7 +344,7 @@ class Fun(commands.Cog):
 			await ctx.send(embed=em)
 		matching = await match_check(ctx, member, action)
 		if not matching:
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if server["fun_module"] == "Disabled":
 				em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 				await message.reply(private=True, embed=em)
@@ -380,7 +380,7 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def punch(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
 		action = "punch"
@@ -389,7 +389,7 @@ class Fun(commands.Cog):
 			await ctx.send(embed=em)
 		matching = await match_check(ctx, member, action)
 		if not matching:
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if server["fun_module"] == "Disabled":
 				em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 				await message.reply(private=True, embed=em)
@@ -425,7 +425,7 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def bite(self, ctx, *, member: guilded.Member=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
 		action = "bite"
@@ -434,7 +434,7 @@ class Fun(commands.Cog):
 			await ctx.send(embed=em)
 		matching = await match_check(ctx, member, action)
 		if not matching:
-			server = await getServer(guild.id)
+			server = await getServer(server.id)
 			if server["fun_module"] == "Disabled":
 				em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 				await message.reply(private=True, embed=em)
@@ -470,10 +470,10 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def cry(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		if server["fun_module"] == "Disabled":
 			em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 			await message.reply(private=True, embed=em)
@@ -509,10 +509,10 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def blush(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		if server["fun_module"] == "Disabled":
 			em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 			await message.reply(private=True, embed=em)
@@ -548,10 +548,10 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def dance(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		if server["fun_module"] == "Disabled":
 			em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 			await message.reply(private=True, embed=em)
@@ -587,10 +587,10 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def shrug(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		if server["fun_module"] == "Disabled":
 			em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 			await message.reply(private=True, embed=em)
@@ -626,10 +626,10 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def wink(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		if server["fun_module"] == "Disabled":
 			em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 			await message.reply(private=True, embed=em)
@@ -665,10 +665,10 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def wave(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		if server["fun_module"] == "Disabled":
 			em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 			await message.reply(private=True, embed=em)
@@ -704,10 +704,10 @@ class Fun(commands.Cog):
 	@commands.command()
 	async def urban(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await command_processed(message, author)
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		if server["fun_module"] == "Disabled":
 			em = guilded.Embed(description="The fun module is disabled in this server.", color=0x363942)
 			await message.reply(private=True, embed=em)
@@ -731,7 +731,7 @@ class Fun(commands.Cog):
 
 async def match_check(ctx, member, action):
 	author = ctx.author
-	guild = ctx.guild
+	server = ctx.server
 	message = ctx.message
 	if author.id == member.id:
 		try:

--- a/modules/general.py
+++ b/modules/general.py
@@ -2,7 +2,7 @@ import guilded
 from guilded.ext import commands
 from tools.dataIO import fileIO
 from modules.generator import _check_values
-from modules.generator import _check_values_guild
+from modules.generator import _check_values_server
 from core.database import *
 from modules.generator import command_processed
 import psycopg
@@ -18,14 +18,14 @@ class General(commands.Cog):
 	@commands.command(pass_context=True)
 	async def changeprefix(self, ctx, pref: str=None):
 		channel = ctx.channel
-		guild = ctx.guild
+		server = ctx.server
 		author = ctx.author
 		message = ctx.message
 		await command_processed(message, author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		try:
-			server = await getServer(guild.id)
-			if author == guild.owner:
+			server = await getServer(server.id)
+			if author == server.owner:
 				if pref == None:
 					em = guilded.Embed(title="Uh oh!", description="You didn't define a prefix.\n\n`Ex: ?changeprefix ;`", color=0x363942)
 					em.set_thumbnail(url="https://img.guildedcdn.com/WebhookThumbnail/aa4b19b0bf393ca43b2f123c22deb94e-Full.webp?w=160&h=160")
@@ -34,9 +34,9 @@ class General(commands.Cog):
 					try:
 						with db_connection.connection() as conn:
 							cursor = conn.cursor()
-							cursor.execute(f"UPDATE servers SET server_prefix = '{pref}' WHERE ID = '{guild.id}'")
+							cursor.execute(f"UPDATE servers SET server_prefix = '{pref}' WHERE ID = '{server.id}'")
 							conn.commit()
-						em = guilded.Embed(title="Success!", description="My prefix in this guild was changed to `{}`".format(str(pref)), color=0x363942)
+						em = guilded.Embed(title="Success!", description="My prefix in this server was changed to `{}`".format(str(pref)), color=0x363942)
 						await ctx.reply(embed=em)
 					except:
 						em = guilded.Embed(title="Uh oh!", description="Unknown error, please contact the Developer.", color=0x363942)
@@ -53,16 +53,16 @@ class General(commands.Cog):
 	@commands.command(pass_context=True)
 	async def togglemodule(self, ctx):
 		channel = ctx.channel
-		guild = ctx.guild
+		server = ctx.server
 		author = ctx.author
 		message = ctx.message
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await command_processed(message, author)
 		try:
 			with db_connection.connection() as conn:
-				server = await getServer(guild.id)
+				server = await getServer(server.id)
 				cursor = conn.cursor()
-				if author == guild.owner:
+				if author == server.owner:
 					fun_status = server["fun_module"]
 					mod_status = server["moderation_module"]
 					if fun_status == "Enabled":
@@ -98,13 +98,13 @@ class General(commands.Cog):
 							if answer1.message.content.lower() in modules:
 								if answer1.message.content.lower() == "fun":
 									if server["fun_module"] == "Enabled":
-										cursor.execute(f"UPDATE servers SET fun_module = 'Disabled' WHERE ID = '{guild.id}'")
+										cursor.execute(f"UPDATE servers SET fun_module = 'Disabled' WHERE ID = '{server.id}'")
 										conn.commit()
 										em = guilded.Embed(title="Success!", description="The Fun module has been disabled.", color=0x363942)
 										await ctx.reply(embed=em)
 								elif answer1.message.content.lower() == "moderation":
 									if server["moderation_module"] == "Enabled":
-										cursor.execute(f"UPDATE servers SET moderation_module = 'Disabled' WHERE ID = '{guild.id}'")
+										cursor.execute(f"UPDATE servers SET moderation_module = 'Disabled' WHERE ID = '{server.id}'")
 										conn.commit()
 										em = guilded.Embed(title="Success!", description="The Moderation module has been disabled.", color=0x363942)
 										await ctx.reply(embed=em)
@@ -139,13 +139,13 @@ class General(commands.Cog):
 							if answer1.message.content.lower() in modules:
 								if answer1.message.content.lower() == "fun":
 									if server["fun_module"] == "Disabled":
-										cursor.execute(f"UPDATE servers SET fun_module = 'Enabled' WHERE ID = '{guild.id}'")
+										cursor.execute(f"UPDATE servers SET fun_module = 'Enabled' WHERE ID = '{server.id}'")
 										conn.commit()
 										em = guilded.Embed(title="Success!", description="The Fun module has been enabled.", color=0x363942)
 										await ctx.reply(embed=em)
 								elif answer1.message.content.lower() == "moderation":
 									if server["moderation_module"] == "Disabled":
-										cursor.execute(f"UPDATE servers SET moderation_module = 'Enabled' WHERE ID = '{guild.id}'")
+										cursor.execute(f"UPDATE servers SET moderation_module = 'Enabled' WHERE ID = '{server.id}'")
 										conn.commit()
 										em = guilded.Embed(title="Success!", description="The Moderation module has been enabled.", color=0x363942)
 										await ctx.reply(embed=em)
@@ -177,7 +177,7 @@ class General(commands.Cog):
 	async def addnote(self, ctx, member: guilded.Member=None, *, note: str=None):
 		author = ctx.message.author
 		channel = ctx.message.channel
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await _check_values(author)
 		await command_processed(message, author)
@@ -219,7 +219,7 @@ class General(commands.Cog):
 	async def delnote(self, ctx, member: guilded.Member=None, *, note: str=None):
 		author = ctx.message.author
 		channel = ctx.message.channel
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await _check_values(author)
 		await command_processed(message, author)
@@ -263,7 +263,7 @@ class General(commands.Cog):
 	async def notes(self, ctx, *, member: guilded.Member=None):
 		author = ctx.message.author
 		channel = ctx.message.channel
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
 		await _check_values(author)
 		await command_processed(message, author)

--- a/modules/generator.py
+++ b/modules/generator.py
@@ -1,3 +1,4 @@
+from asyncio.base_events import Server
 import guilded
 from guilded.ext import commands
 import json
@@ -69,61 +70,61 @@ class Generator(commands.Cog):
 	@commands.Cog.listener()
 	async def on_member_remove(self, event: guilded.MemberRemoveEvent):
 		author = event.member
-		guild = event.server
+		server = event.server
 		kicked = event.kicked
 		banned = event.banned
 		if author.bot:
 			return
-		await _check_values_guild(guild)
-		server = await getServer(guild.id)
+		await _check_values_server(server)
+		server = await getServer(server.id)
 		if server["log_actions"] == None:
 			return
 		if banned == True:
-			channel = await guild.fetch_channel(server["log_actions"])
+			channel = await server.fetch_channel(server["log_actions"])
 			em = guilded.Embed(title="A member was banned:", description="`Username:` {}\n`User ID:` {}".format(author.name, author.id), color=0x363942)
 			await channel.send(embed=em)
 		elif kicked  == True:
-			channel = await guild.fetch_channel(server["log_actions"])
+			channel = await server.fetch_channel(server["log_actions"])
 			em = guilded.Embed(title="A member was kicked:", description="`Username:` {}\n`User ID:` {}".format(author.name, author.id), color=0x363942)
 			await channel.send(embed=em)
 		else:
-			channel = await guild.fetch_channel(server["log_traffic"])
+			channel = await server.fetch_channel(server["log_traffic"])
 			em = guilded.Embed(title="A member has left:", description="`Username:` {}\n`User ID:` {}".format(author.name, author.id), color=0x363942)
 			await channel.send(embed=em)
 
 	@commands.Cog.listener()
 	async def on_bot_add(self, event: guilded.BotAddEvent):
-		guild = event.server
+		server = event.server
 		user = event.member
 		author = user
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await _check_inventory(author)
-		send_channel = await guild.fetch_default_channel()
-		support_guild = await self.bot.fetch_server("Mldgz04R")
-		channel = await support_guild.fetch_channel("fd818fb2-c102-4ce9-b347-23d00a5649f8")
-		await _check_values_guild(guild)
-		em = guilded.Embed(title="Hello community!", description="`-` Thanks <@{}> for inviting me to **{}!**\n`-` My default prefix/help command is `?help`\n`-` Rayz is a multipurpose bot featuring moderation, logging, a global economy, interaction commands, and more!\n\n**Links**\n[Support server](https://guilded.gg/Rayz) • [Invite Rayz](https://www.guilded.gg/b/acd5fc8c-4272-48d0-b78b-da1fecb1bab5)".format(user.id, guild.name), color=0x363942)
+		send_channel = await server.fetch_default_channel()
+		support_server = await self.bot.fetch_server("Mldgz04R")
+		channel = await support_server.fetch_channel("fd818fb2-c102-4ce9-b347-23d00a5649f8")
+		await _check_values_server(Server)
+		em = guilded.Embed(title="Hello community!", description="`-` Thanks <@{}> for inviting me to **{}!**\n`-` My default prefix/help command is `?help`\n`-` Rayz is a multipurpose bot featuring moderation, logging, a global economy, interaction commands, and more!\n\n**Links**\n[Support server](https://guilded.gg/Rayz) • [Invite Rayz](https://www.guilded.gg/b/acd5fc8c-4272-48d0-b78b-da1fecb1bab5)".format(user.id, server.name), color=0x363942)
 		await send_channel.send(embed=em)
-		em = guilded.Embed(title="Rayz joined a Guild!", description="**__{}__**\n**Inivted by:** `{} ({})`".format(guild.name, user.name, user.id), color=0x363942)
+		em = guilded.Embed(title="Rayz joined a server!", description="**__{}__**\n**Inivted by:** `{} ({})`".format(server.name, user.name, user.id), color=0x363942)
 		await channel.send(embed=em)
 
 	@commands.Cog.listener()
 	async def on_member_join(self, event: guilded.MemberJoinEvent):
 		author = event.member
-		guild = event.server
+		server = event.server
 		if author.bot:
 			return
-		await _check_values_guild(guild)
-		server = await getServer(guild.id)
+		await _check_values_server(server)
+		server = await getServer(server.id)
 		if server["welcome_channel"] == None:
 			pass
 		else:
 			try:
-				channel = await guild.fetch_channel(server["welcome_channel"])
+				channel = await server.fetch_channel(server["welcome_channel"])
 				if server["welcome_message"] == None:
-					welcome_message = f"Welcome <@{author.id}> to {guild.name}!"
+					welcome_message = f"Welcome <@{author.id}> to {server.name}!"
 				else:
 					welcome_message = server["welcome_message"]
 				try:
@@ -131,12 +132,12 @@ class Generator(commands.Cog):
 				except:
 					pass
 				try:
-					welcome_message = welcome_message.replace("<server>", f"{guild.name}")
+					welcome_message = welcome_message.replace("<server>", f"{server.name}")
 				except:
 					pass
 				em = guilded.Embed(title="A member has joined!", description="{}".format(welcome_message), color=0x363942)
 				try:
-					em.set_thumbnail(url=guild.icon)
+					em.set_thumbnail(url=server.icon)
 				except:
 					pass
 				await channel.send(embed=em)
@@ -145,24 +146,24 @@ class Generator(commands.Cog):
 			if server["log_traffic"] == None:
 				pass
 			else:
-				channel = await guild.fetch_channel(server["log_traffic"])
+				channel = await server.fetch_channel(server["log_traffic"])
 				em = guilded.Embed(title="A member has joined:", description="`Username:` {}\n`User ID:` {}".format(author.name, author.id), color=0x363942)
 				await channel.send(embed=em)
 
 	@commands.Cog.listener()
 	async def on_message(self, event: guilded.MessageEvent):
 		author = event.message.author
-		guild = event.server
+		server = event.server
 		message = event.message
 		if event.message.created_by_bot:
 			return
 		await _check_values(author)
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await check_leaderboard(author)
 		await check_leaderboard_author(author)
 		info = fileIO("config/banned_words.json", "load")
 
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		prefix = server["server_prefix"]
 		if server["custom_blocked_words"] == None:
 			append_it = ["111111111111111111111111111111111111111111111111111111111111111111111111111111111"]
@@ -191,7 +192,7 @@ class Generator(commands.Cog):
 					await message.delete()
 				else:
 					try:
-						channel = await guild.fetch_channel(server["logs_channel_id"])
+						channel = await server.fetch_channel(server["logs_channel_id"])
 						em = guilded.Embed(title="A blacklisted word was used.", description="**User** {}\n**ID:** {}\n\n__**READ AT YOUR OWN RISK**__\n`Captures:`\n{}\n\n`Message content:`\n{}".format(author.name, author.id, " \n".join(captures), message.content), color=0x363942)
 						await channel.send(embed=em)
 						em = guilded.Embed(title="A blacklisted word was used.", description="<@{}> **said:**\n{}".format(author.id, " \n".join(things_said)), color=0x363942)
@@ -206,17 +207,17 @@ class Generator(commands.Cog):
 
 	@commands.Cog.listener()
 	async def on_message_update(self, event: guilded.MessageUpdateEvent):
-		guild = event.server
+		server = event.server
 		author = event.before.author
 		before = event.before
 		after = event.after
 		if before.created_by_bot:
 			return
 
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		if server["logs_channel_id"] is not None:
 			try:
-				channel = await guild.fetch_channel(server["logs_channel_id"])
+				channel = await server.fetch_channel(server["logs_channel_id"])
 				em = guilded.Embed(title="Message edit event.", description="**User:** {}\n**ID:** {}\n\n__**EDIT EVENT**__\n`Before:`\n{}\n\n`After:`\n{}".format(author.name, author.id, before.content, after.content), color=0x363942)
 				await channel.send(embed=em)
 			except:
@@ -226,17 +227,17 @@ class Generator(commands.Cog):
 
 	@commands.Cog.listener()
 	async def on_message_delete(self, event: guilded.MessageDeleteEvent):
-		guild = event.server
+		server = event.server
 		author = event.message.author
 		channel = event.channel
 		message = event.message
 		if message.created_by_bot:
 			return
 
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		if server["logs_channel_id"] is not None:
 			try:
-				channel = await guild.fetch_channel(server["logs_channel_id"])
+				channel = await server.fetch_channel(server["logs_channel_id"])
 				em = guilded.Embed(title="Message delete event.", description="**User:** {}\n**ID:** {}\n\n__**DELETE EVENT**__\n**Deleted message:** {}".format(author.name, author.id, message.content), color=0x363942)
 				await channel.send(embed=em)
 			except:
@@ -424,13 +425,13 @@ async def _check_values(author):
 	except psycopg.DatabaseError as e:
 		print(f'Error {e}')
 
-async def _check_values_guild(guild):
+async def _check_values_server(server):
 	try:
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		with db_connection.connection() as conn:
 			if server == None:
 				cursor = conn.cursor()
-				cursor.execute(f"INSERT INTO servers(id, logs_channel_id, server_prefix, partner_status, economy_multiplier, moderation_module, fun_module, economy_module) VALUES('{guild.id}', 'None', '?', 'False', 1, 'Enabled', 'Enabled', 'Enabled')")
+				cursor.execute(f"INSERT INTO servers(id, logs_channel_id, server_prefix, partner_status, economy_multiplier, moderation_module, fun_module, economy_module) VALUES('{server.id}', 'None', '?', 'False', 1, 'Enabled', 'Enabled', 'Enabled')")
 				conn.commit()
 	except psycopg.DatabaseError as e:
 		print(f'Error {e}')

--- a/modules/help.py
+++ b/modules/help.py
@@ -4,7 +4,7 @@ from modules.generator import _check_values
 from modules.generator import _check_inventory
 from modules.generator import _check_inventory_member
 from modules.generator import _check_values_member
-from modules.generator import _check_values_guild
+from modules.generator import _check_values_server
 from modules.generator import check_leaderboard
 from modules.generator import check_leaderboard_author
 from modules.generator import command_processed
@@ -23,19 +23,19 @@ class Help(commands.Cog):
 	@commands.command()
 	async def help(self, ctx, *, num: str=None):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
-		await _check_values_guild(guild)
+		await _check_values_server(server)
 		await command_processed(message, author)
 		await _check_values(author)
 
 		economy_settings = fileIO("config/economy_settings.json", "load")
 		config = fileIO("config/config.json", "load")
 
-		support_guild = await self.bot.fetch_server(economy_settings["support_server_id"])
-		members_support_guild = await support_guild.fetch_members()
+		support_server = await self.bot.fetch_server(economy_settings["support_server_id"])
+		members_support_server = await support_server.fetch_members()
 
-		server = await getServer(guild.id)
+		server = await getServer(server.id)
 		last_update = "{}".format(config["last_updated"])
 		prefix = server["server_prefix"]
 
@@ -53,9 +53,9 @@ class Help(commands.Cog):
 			economy_status = "Disabled"
 
 		display_list = ["`1` • General `-` Enabled", "`2` • Fun `-` {}".format(fun_status), "`3` • Moderation `-` {}".format(mod_status), "`4` • Economy module `-` {}".format(economy_status)]
-		if author in members_support_guild:
-			author_support_guild = await support_guild.fetch_member(author.id)
-			roles_list = await author_support_guild.fetch_role_ids()
+		if author in members_support_server:
+			author_support_server = await support_server.fetch_member(author.id)
+			roles_list = await author_support_server.fetch_role_ids()
 			if config["staff_role_id"] in roles_list:
 				display_list.append("`5` • Support staff `-` Enabled")
 			if config["manager_role_id"] in roles_list:
@@ -76,11 +76,11 @@ class Help(commands.Cog):
 			em.set_footer(text=f"{last_update}")
 			await ctx.send(embed=em)
 		elif num == "3" or num.lower() == "mod" or num.lower() == "moderation" or num.lower() == "moderation module":
-			em = guilded.Embed(title="Moderation Module | Page 3", description=f"[optional] • <required>\n\n**Currently, only server owners can execute these commands.**\n\n__**Moderation**__ [{mod_status}]\n{prefix}changeprefix <prefix> `-` Change the prefix in this guild.\n{prefix}togglemodule `-` Toggle modules for your guild.\n{prefix}setlogchannel `-` Set the current channel to post logs in.\n{prefix}banword <word argument> `-` Bans usage of a word/phrase you don't like.\n{prefix}unbanword <word argument> `-` Unban usage of a word/phrase.\n{prefix}kick <user> `-` Kick a user from a Guild.\n{prefix}ban <user> `-` Ban a user from a Guild.\n{prefix}channelid `-` Get the channel ID in the channel you post this in.\n{prefix}settrafficlogs `-` Set the current channel to post traffic logs in.\n{prefix}setactionlogs `-` Set the current channel to post action logs in.\n{prefix}setwelcomechannel `-` Set the current channel to post welcome messages in.\n{prefix}setwelcomemessage <message> `-` Change the welcome message.\n\n[Invite Rayz](https://www.guilded.gg/b/e249e5b0-cbd9-4318-92bb-9cc7fb8c6778)\n[Support Server](https://guilded.gg/Rayz)", color=0x363942)
+			em = guilded.Embed(title="Moderation Module | Page 3", description=f"[optional] • <required>\n\n**Currently, only server owners can execute these commands.**\n\n__**Moderation**__ [{mod_status}]\n{prefix}changeprefix <prefix> `-` Change the prefix in this server.\n{prefix}togglemodule `-` Toggle modules for your server.\n{prefix}setlogchannel `-` Set the current channel to post logs in.\n{prefix}banword <word argument> `-` Bans usage of a word/phrase you don't like.\n{prefix}unbanword <word argument> `-` Unban usage of a word/phrase.\n{prefix}kick <user> `-` Kick a user from a server.\n{prefix}ban <user> `-` Ban a user from a server.\n{prefix}channelid `-` Get the channel ID in the channel you post this in.\n{prefix}settrafficlogs `-` Set the current channel to post traffic logs in.\n{prefix}setactionlogs `-` Set the current channel to post action logs in.\n{prefix}setwelcomechannel `-` Set the current channel to post welcome messages in.\n{prefix}setwelcomemessage <message> `-` Change the welcome message.\n\n[Invite Rayz](https://www.guilded.gg/b/e249e5b0-cbd9-4318-92bb-9cc7fb8c6778)\n[Support Server](https://guilded.gg/Rayz)", color=0x363942)
 			em.set_footer(text=f"{last_update}")
 			await ctx.send(embed=em)
 		elif num == "4" or num.lower() == "economy" or num.lower() == "economy module":
-			em = guilded.Embed(title="Economy Module | Page 4", description=f"[optional] • <required>\n\n__**Economy**__ [{economy_status}]\n{prefix}profile `-` Display profile, and balance information.\n{prefix}work `-` Work for currency\n{prefix}weekly `-` Receive your weekly bonus.\n{prefix}gift <amount> <user> `-` Gift currency to a user.\n{prefix}withdraw <amount/all> `-` Make a withdraw from your bank.\n{prefix}deposit <amount/all> `-` Make a depsosit into your bank.\n{prefix}stats `-` View the economy settings for the guild.\n{prefix}leaderboard `-` Display the global economy leaderboard.\n{prefix}gift <amount> <user> `-` Gift others your currency.\n{prefix}give <item> <amount> <user> `-` Give others your items.\n{prefix}rob <user> `-` Rob money from people.\n{prefix}sell <item> `-` Sell your items.\n{prefix}dig `-` Dig up things!\n{prefix}prices `-` View a list of sellable item prices.\n{prefix}inventory `-` View your inventory.\n{prefix}slots <amount> `-` Bet and play some slots.\n\n[Invite Rayz](https://www.guilded.gg/b/e249e5b0-cbd9-4318-92bb-9cc7fb8c6778)\n[Support Server](https://guilded.gg/Rayz)", color=0x363942)
+			em = guilded.Embed(title="Economy Module | Page 4", description=f"[optional] • <required>\n\n__**Economy**__ [{economy_status}]\n{prefix}profile `-` Display profile, and balance information.\n{prefix}work `-` Work for currency\n{prefix}weekly `-` Receive your weekly bonus.\n{prefix}gift <amount> <user> `-` Gift currency to a user.\n{prefix}withdraw <amount/all> `-` Make a withdraw from your bank.\n{prefix}deposit <amount/all> `-` Make a depsosit into your bank.\n{prefix}stats `-` View the economy settings for the server.\n{prefix}leaderboard `-` Display the global economy leaderboard.\n{prefix}gift <amount> <user> `-` Gift others your currency.\n{prefix}give <item> <amount> <user> `-` Give others your items.\n{prefix}rob <user> `-` Rob money from people.\n{prefix}sell <item> `-` Sell your items.\n{prefix}dig `-` Dig up things!\n{prefix}prices `-` View a list of sellable item prices.\n{prefix}inventory `-` View your inventory.\n{prefix}slots <amount> `-` Bet and play some slots.\n\n[Invite Rayz](https://www.guilded.gg/b/e249e5b0-cbd9-4318-92bb-9cc7fb8c6778)\n[Support Server](https://guilded.gg/Rayz)", color=0x363942)
 			em.set_footer(text=f"{last_update}")
 			await ctx.send(embed=em)
 		elif num == "5" or num.lower() == "staff" or num.lower() == "support":

--- a/modules/moderation.py
+++ b/modules/moderation.py
@@ -16,20 +16,20 @@ class Moderation(commands.Cog):
 
 	@commands.command()
 	async def setwelcomemessage(self, ctx, *, arg: str=None):
-		guild = ctx.guild
+		server = ctx.server
 		author = ctx.author
 		message = ctx.message
 		await command_processed(message, author)
-		if author == guild.owner:
+		if author == server.owner:
 			if arg == None:
 				em = guilded.Embed(title="Uh oh!", description="Message cannot be None.\n\n**Replaced methods:**\n`<server>` is replaced with the server name.\n`<user>` is replaced with the user.\n\n**Example:**\n`setwelcomemessage <user>, welcome to <server>!`", color=0x363942)
 				await ctx.reply(embed=em)
 				return
 			try:
 				with db_connection.connection() as conn:
-					server = await getServer(guild.id)
+					server = await getServer(server.id)
 					cursor = conn.cursor()
-					cursor.execute(f"UPDATE servers SET welcome_message = '{arg}' WHERE ID = '{guild.id}'")
+					cursor.execute(f"UPDATE servers SET welcome_message = '{arg}' WHERE ID = '{server.id}'")
 					conn.commit()
 					em = guilded.Embed(title="New welcome message set", description="{}".format(arg), color=0x363942)
 					await ctx.reply(embed=em)
@@ -42,23 +42,23 @@ class Moderation(commands.Cog):
 
 	@commands.command()
 	async def settrafficlogs(self, ctx, *, arg: str=None):
-		guild = ctx.guild
+		server = ctx.server
 		author = ctx.author
 		message = ctx.message
 		await command_processed(message, author)
-		if author == guild.owner:
+		if author == server.owner:
 			try:
 				with db_connection.connection() as conn:
 					cursor = conn.cursor()
-					server = await getServer(guild.id)
+					server = await getServer(server.id)
 					if not arg == None:
 						if arg.lower() == "none" or arg.lower() == "reset":
-							cursor.execute(f"UPDATE servers SET log_traffic = 'None' WHERE ID = '{guild.id}'")
+							cursor.execute(f"UPDATE servers SET log_traffic = 'None' WHERE ID = '{server.id}'")
 							conn.commit()
 							em = guilded.Embed(title="Traffic channel reset", description="None", color=0x363942)
 							await ctx.reply(embed=em)
 					else:
-						cursor.execute(f"UPDATE servers SET log_traffic = '{ctx.channel.id}' WHERE ID = '{guild.id}'")
+						cursor.execute(f"UPDATE servers SET log_traffic = '{ctx.channel.id}' WHERE ID = '{server.id}'")
 						conn.commit()
 						em = guilded.Embed(title="Traffic channel set", description="{}".format(ctx.channel.id), color=0x363942)
 						await ctx.reply(embed=em)
@@ -71,23 +71,23 @@ class Moderation(commands.Cog):
 
 	@commands.command()
 	async def setactionlogs(self, ctx, *, arg: str=None):
-		guild = ctx.guild
+		server = ctx.server
 		author = ctx.author
 		message = ctx.message
 		await command_processed(message, author)
-		if author == guild.owner:
+		if author == server.owner:
 			try:
 				with db_connection.connection() as conn:
 					cursor = conn.cursor()
-					server = await getServer(guild.id)
+					server = await getServer(server.id)
 					if not arg == None:
 						if arg.lower() == "none" or arg.lower() == "reset":
-							cursor.execute(f"UPDATE servers SET log_actions = 'None' WHERE ID = '{guild.id}'")
+							cursor.execute(f"UPDATE servers SET log_actions = 'None' WHERE ID = '{server.id}'")
 							conn.commit()
 							em = guilded.Embed(title="Action channel reset", description="None", color=0x363942)
 							await ctx.reply(embed=em)
 					else:
-						cursor.execute(f"UPDATE servers SET log_actions = '{ctx.channel.id}' WHERE ID = '{guild.id}'")
+						cursor.execute(f"UPDATE servers SET log_actions = '{ctx.channel.id}' WHERE ID = '{server.id}'")
 						conn.commit()
 						em = guilded.Embed(title="Action channel set", description="{}".format(ctx.channel.id), color=0x363942)
 						await ctx.reply(embed=em)
@@ -100,23 +100,23 @@ class Moderation(commands.Cog):
 
 	@commands.command()
 	async def setwelcomechannel(self, ctx, *, arg: str=None):
-		guild = ctx.guild
+		server = ctx.server
 		author = ctx.author
 		message = ctx.message
 		await command_processed(message, author)
-		if author == guild.owner:
+		if author == server.owner:
 			try:
 				with db_connection.connection() as conn:
 					cursor = conn.cursor()
-					server = await getServer(guild.id)
+					server = await getServer(server.id)
 					if not arg == None:
 						if arg.lower() == "none" or arg.lower() == "reset":
-							cursor.execute(f"UPDATE servers SET welcome_channel = 'None' WHERE ID = '{guild.id}'")
+							cursor.execute(f"UPDATE servers SET welcome_channel = 'None' WHERE ID = '{server.id}'")
 							conn.commit()
 							em = guilded.Embed(title="Welcome channel reset", description="None", color=0x363942)
 							await ctx.reply(embed=em)
 					else:
-						cursor.execute(f"UPDATE servers SET welcome_channel = '{ctx.channel.id}' WHERE ID = '{guild.id}'")
+						cursor.execute(f"UPDATE servers SET welcome_channel = '{ctx.channel.id}' WHERE ID = '{server.id}'")
 						conn.commit()
 						em = guilded.Embed(title="Welcome channel set", description="{}".format(ctx.channel.id), color=0x363942)
 						await ctx.reply(embed=em)
@@ -129,7 +129,7 @@ class Moderation(commands.Cog):
 
 	@commands.command()
 	async def addowner(self, ctx, *, member: guilded.Member=None):
-		guild = ctx.guild
+		server = ctx.server
 		author = ctx.author
 		message = ctx.message
 		await command_processed(message, author)
@@ -140,12 +140,12 @@ class Moderation(commands.Cog):
 		try:
 			with db_connection.connection() as conn:
 				cursor = conn.cursor()
-				server = await getServer(guild.id)
+				server = await getServer(server.id)
 				list_people = []
 				list_people_display = []
 				if server[9] == None:
 					list_people.append(member.id)
-					stmt = f"UPDATE servers SET server_owners=%s WHERE ID = '{guild.id}'"
+					stmt = f"UPDATE servers SET server_owners=%s WHERE ID = '{server.id}'"
 					cursor.execute(stmt, (list_people,))
 					conn.commit()
 					em = guilded.Embed(title="New owner added:", description="<@{}>".format(member.id), color=0x363942)
@@ -160,7 +160,7 @@ class Moderation(commands.Cog):
 						await ctx.reply(embed=em)
 					else:
 						list_people.append(member.id)
-						stmt = f"UPDATE servers SET server_owners=%s WHERE ID = '{guild.id}'"
+						stmt = f"UPDATE servers SET server_owners=%s WHERE ID = '{server.id}'"
 						cursor.execute(stmt, (list_people,))
 						conn.commit()
 						em = guilded.Embed(title="New owner added:", description="<@{}>\n\n__**Current owners:**__\n{}\n<@{}>".format(member.id, " \n".join(list_people_display), member.id), color=0x363942)
@@ -171,14 +171,14 @@ class Moderation(commands.Cog):
 
 	@commands.command()
 	async def unbanword(self, ctx, *, word: str=None):
-		guild = ctx.guild
+		server = ctx.server
 		author = ctx.author
 		message = ctx.message
 		await command_processed(message, author)
 		try:
 			with db_connection.connection() as conn:
 				cursor = conn.cursor()
-				server = await getServer(guild.id)
+				server = await getServer(server.id)
 				prefix = server["server_prefix"]
 				channel = ctx.message.channel
 				if server["moderation_module"] == "Disabled":
@@ -194,7 +194,7 @@ class Moderation(commands.Cog):
 				for i in author.roles:
 					if i.permissions.manage_messages == True or i.permissions.kick_members == True:
 						moderator_or_not = True
-				if author == guild.owner:
+				if author == server.owner:
 					moderator_or_not = True
 				if moderator_or_not == True:
 					if server["custom_blocked_words"] == None:
@@ -208,7 +208,7 @@ class Moderation(commands.Cog):
 							list_server.append(i)
 						if str(word).lower() in list_server:
 							list_server.remove(str(word).lower())
-							stmt = f"UPDATE servers SET custom_blocked_words=%s WHERE ID = '{guild.id}'"
+							stmt = f"UPDATE servers SET custom_blocked_words=%s WHERE ID = '{server.id}'"
 							cursor.execute(stmt, (list_server,))
 							conn.commit()
 							em = guilded.Embed(title="Nice!", description="The word argument has been unbanned.", color=0x363942)
@@ -225,14 +225,14 @@ class Moderation(commands.Cog):
 
 	@commands.command()
 	async def banword(self, ctx, *, word: str=None):
-		guild = ctx.guild
+		server = ctx.server
 		author = ctx.author
 		message = ctx.message
 		await command_processed(message, author)
 		try:
 			with db_connection.connection() as conn:
 				cursor = conn.cursor()
-				server = await getServer(guild.id)
+				server = await getServer(server.id)
 				prefix = server["server_prefix"]
 				channel = ctx.message.channel
 				if server["moderation_module"] == "Disabled":
@@ -248,7 +248,7 @@ class Moderation(commands.Cog):
 				for i in author.roles:
 					if i.permissions.manage_messages == True or i.permissions.kick_members == True:
 						moderator_or_not = True
-				if author == guild.owner:
+				if author == server.owner:
 					moderator_or_not = True
 				if moderator_or_not == True:
 					wordlist = []
@@ -264,7 +264,7 @@ class Moderation(commands.Cog):
 					else:
 						if server["custom_blocked_words"] == None:
 							new_value = ["{}".format(word.lower())]
-							stmt = f"UPDATE servers SET custom_blocked_words=%s WHERE ID = '{guild.id}'"
+							stmt = f"UPDATE servers SET custom_blocked_words=%s WHERE ID = '{server.id}'"
 							cursor.execute(stmt, (new_value,))
 							conn.commit()
 							em = guilded.Embed(title="Nice!", description="The word argument has been banned.", color=0x363942)
@@ -274,7 +274,7 @@ class Moderation(commands.Cog):
 							for i in server["custom_blocked_words"]:
 								list_server.append(i)
 							list_server.append(word.lower())
-							stmt = f"UPDATE servers SET custom_blocked_words=%s WHERE ID = '{guild.id}'"
+							stmt = f"UPDATE servers SET custom_blocked_words=%s WHERE ID = '{server.id}'"
 							cursor.execute(stmt, (list_server,))
 							conn.commit()
 							em = guilded.Embed(title="Nice!", description="The word argument has been banned.", color=0x363942)
@@ -289,10 +289,10 @@ class Moderation(commands.Cog):
 
 	@commands.command()
 	async def kick(self, ctx, *, member: guilded.Member=None):
-		guild = await self.bot.fetch_server(ctx.guild.id)
-		author = await guild.fetch_member(ctx.author.id)
+		server = await self.bot.fetch_server(ctx.server.id)
+		author = await server.fetch_member(ctx.author.id)
 		message = ctx.message
-		info = fileIO("guilds/{}/info.json".format(guild.id), "load")
+		info = fileIO("guilds/{}/info.json".format(server.id), "load")
 		channel = ctx.message.channel
 		if info["moderation_module"] == "Disabled":
 			em = guilded.Embed(description="The moderation module is disabled in this server.", color=0x363942)
@@ -306,7 +306,7 @@ class Moderation(commands.Cog):
 		for i in author.roles:
 			if i.permissions.manage_messages == True or i.permissions.kick_members == True:
 				moderator_or_not = True
-		if author == guild.owner:
+		if author == server.owner:
 			moderator_or_not = True
 		if moderator_or_not == True:
 			if member == None:
@@ -324,11 +324,11 @@ class Moderation(commands.Cog):
 
 	@commands.command()
 	async def ban(self, ctx, *, member: guilded.Member=None):
-		guild = await self.bot.fetch_server(ctx.guild.id)
-		author = await guild.fetch_member(ctx.message.author.id)
+		server = await self.bot.fetch_server(ctx.server.id)
+		author = await server.fetch_member(ctx.message.author.id)
 		channel = ctx.message.channel
 		message = ctx.message
-		info = fileIO("guilds/{}/info.json".format(guild.id), "load")
+		info = fileIO("guilds/{}/info.json".format(server.id), "load")
 		if info["moderation_module"] == "Disabled":
 			em = guilded.Embed(description="The moderation module is disabled in this server.", color=0x363942)
 			await message.reply(private=True, embed=em)
@@ -341,7 +341,7 @@ class Moderation(commands.Cog):
 		for i in author.roles:
 			if i.permissions.manage_messages == True or i.permissions.ban_members == True:
 				moderator_or_not = True
-		if author == guild.owner:
+		if author == server.owner:
 			moderator_or_not = True
 		if moderator_or_not == True:
 			if member == None:
@@ -359,7 +359,7 @@ class Moderation(commands.Cog):
 
 	@commands.command()
 	async def setlogchannel(self, ctx, *, arg: str=None):
-		guild = ctx.guild
+		server = ctx.server
 		author = ctx.author
 		channel = ctx.message.channel
 		message = ctx.message
@@ -368,22 +368,22 @@ class Moderation(commands.Cog):
 		for i in author.roles:
 			if i.permissions.manage_messages == True or i.permissions.kick_members == True:
 				moderator_or_not = True
-		if author == guild.owner:
+		if author == server.owner:
 			moderator_or_not = True
 		if moderator_or_not == True:
 			try:
 				with db_connection.connection() as conn:
-					server = await getServer(guild.id)
+					server = await getServer(server.id)
 					if not arg == None:
 						if arg.lower() == "none" or arg.lower() == "reset":
 							cursor = conn.cursor()
-							cursor.execute(f"UPDATE servers SET logs_channel_id = 'None' WHERE ID = '{guild.id}'")
+							cursor.execute(f"UPDATE servers SET logs_channel_id = 'None' WHERE ID = '{server.id}'")
 							conn.commit()
 							em = guilded.Embed(title="Logs channel reset", description="None", color=0x363942)
 							await ctx.reply(embed=em)
 					else:
 						cursor = conn.cursor()
-						cursor.execute(f"UPDATE servers SET logs_channel_id = '{ctx.channel.id}' WHERE ID = '{guild.id}'")
+						cursor.execute(f"UPDATE servers SET logs_channel_id = '{ctx.channel.id}' WHERE ID = '{server.id}'")
 						conn.commit()
 						em = guilded.Embed(title="Logs channel set", description="{}".format(ctx.channel.id), color=0x363942)
 						await ctx.reply(embed=em)
@@ -397,15 +397,15 @@ class Moderation(commands.Cog):
 	@commands.command()
 	async def channelid(self, ctx):
 		author = ctx.author
-		guild = ctx.guild
+		server = ctx.server
 		message = ctx.message
-		channel = await guild.fetch_channel(ctx.channel.id)
+		channel = await server.fetch_channel(ctx.channel.id)
 		await command_processed(message, author)
 		moderator_or_not = False
 		for i in author.roles:
 			if i.permissions.manage_messages == True or i.permissions.kick_members == True:
 				moderator_or_not = True
-		if author == guild.owner:
+		if author == server.owner:
 			moderator_or_not = True
 		if moderator_or_not == True:
 			em = guilded.Embed(title="Channel ID retrieved.", description="{}".format(channel.id), color=0x363942)
@@ -414,33 +414,34 @@ class Moderation(commands.Cog):
 	@commands.command()
 	@checks.is_dev()
 	async def info(self, ctx):
-		guild = ctx.guild
-		author = await guild.fetch_member(ctx.message.author.id)
+		server = ctx.server
+		author = await server.fetch_member(ctx.message.author.id)
 		channel = ctx.message.channel
 		latency = str(self.bot.latency)
 		member_count = 0
-		for i in self.bot.guilds:
+		servers = await self.bot.fetch_servers()
+		for i in servers:
 			member_count += i.member_count
-		em = guilded.Embed(title="Rayz's Information", description="**Guilds:** {}\n**Ping:** {}{}ms\n**Users:** {}".format(len(self.bot.guilds), latency[2], latency[3], member_count), color=0x363942)
-		em.set_footer(text="Reminder: This is only what's cached (It gets reset often). It doesn't display ALL information.")
+		em = guilded.Embed(title="Rayz's Information", description="**Servers:** {}\n**Ping:** {}{}ms\n**Users:** {}".format(len(self.bot.guilds), latency[2], latency[3], member_count), color=0x363942)
 		await ctx.reply(embed=em)
 
 	@commands.command()
 	@checks.is_dev()
-	async def guildlist(self, ctx):
+	async def serverlist(self, ctx):
 		author = ctx.message.author
 		channel = ctx.message.channel
-		guild = ctx.guild
-		guild_list = []
-		for i in self.bot.guilds:
-			guild_list.append(i.name)
-		em = guilded.Embed(title="Rayz's Guild list", description="**Guilds:**\n{}".format(" \n".join(guild_list)), color=0x363942)
+		server = ctx.server
+		server_lista = await self.bot.fetch_servers()
+		server_list = []
+		for i in server_lista:
+			server_list.append(i.name)
+		em = guilded.Embed(title="Rayz's server list", description="**Servers:**\n{}".format(" \n".join(server_list)), color=0x363942)
 		await ctx.reply(embed=em)
 
 async def kick_check(self, ctx, member):
 	author = ctx.author
-	guild = ctx.guild
-	baka = guild.get_member("m6oLkqLA")
+	server = ctx.server
+	baka = server.get_member("m6oLkqLA")
 	bot_has_perms = False
 	bots_highest_role_num = -10000
 	members_highest_role_num = -10000
@@ -479,13 +480,13 @@ async def kick_check(self, ctx, member):
 					return
 				await member.kick()
 				em1 = guilded.Embed(title="User kicked.", description="**{}** was successfully kicked by <@{}>".format(member_name, author.id), color=0x363942)
-				info = fileIO("guilds/{}/info.json".format(guild.id), "load")
+				info = fileIO("guilds/{}/info.json".format(server.id), "load")
 				if info["logs_channel_id"] == "None":
 					em1.set_footer(icon_url= "https://img.guildedcdn.com/WebhookThumbnail/aa4b19b0bf393ca43b2f123c22deb94e-Full.webp?w=160&h=160", text="Logs channel not set.")
 				else:
 					try:
-						guild = await self.bot.fetch_team(ctx.guild.id)
-						channel = await guild.fetch_channel(info["logs_channel_id"])
+						server = await self.bot.fetch_team(ctx.server.id)
+						channel = await server.fetch_channel(info["logs_channel_id"])
 						em = guilded.Embed(title="A user was kicked.", description="**Name:** {}\n**ID:** {}".format(member.name, member.id), color=0x363942)
 						em.set_footer(icon_url= "https://img.guildedcdn.com/WebhookThumbnail/aa4b19b0bf393ca43b2f123c22deb94e-Full.webp?w=160&h=160", text="Kicked by {}".format(author.name))
 						await channel.send(embed=em)
@@ -496,8 +497,8 @@ async def kick_check(self, ctx, member):
 
 async def ban_check(self, ctx, member):
 	author = ctx.author
-	guild = ctx.guild
-	baka = guild.get_member("m6oLkqLA")
+	server = ctx.server
+	baka = server.get_member("m6oLkqLA")
 	bot_has_perms = False
 	bots_highest_role_num = -10000
 	members_highest_role_num = -10000
@@ -536,13 +537,13 @@ async def ban_check(self, ctx, member):
 					return
 				await member.ban()
 				em1 = guilded.Embed(title="User banned.", description="**{}** was successfully banned by <@{}>".format(member_name, author.id), color=0x363942)
-				info = fileIO("guilds/{}/info.json".format(guild.id), "load")
+				info = fileIO("guilds/{}/info.json".format(server.id), "load")
 				if info["logs_channel_id"] == "None":
 					em1.set_footer(icon_url= "https://img.guildedcdn.com/WebhookThumbnail/aa4b19b0bf393ca43b2f123c22deb94e-Full.webp?w=160&h=160", text="Logs channel not set.")
 				else:
 					try:
-						guild = await self.bot.fetch_team(ctx.guild.id)
-						channel = await guild.fetch_channel(info["logs_channel_id"])
+						server = await self.bot.fetch_team(ctx.server.id)
+						channel = await server.fetch_channel(info["logs_channel_id"])
 						em = guilded.Embed(title="A user was banned.", description="**Name:** {}\n**ID:** {}".format(member.name, member.id), color=0x363942)
 						em.set_footer(icon_url= "https://img.guildedcdn.com/WebhookThumbnail/aa4b19b0bf393ca43b2f123c22deb94e-Full.webp?w=160&h=160", text="Banned by {}".format(author.name))
 						await channel.send(embed=em)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.8.3
-guilded.py==1.5.0
+guilded.py==1.8.0
 psycopg2==2.9.3
 asyncio==3.4.3
 quart==0.18.3
@@ -11,4 +11,3 @@ requests==2.27.1
 regex==2022.10.31
 hypercorn==0.14.3
 simplejson==3.18.3
-# asyncpg==0.27.0 - This is coming soon! (YumYummity)

--- a/tools/permissions.py
+++ b/tools/permissions.py
@@ -2,8 +2,8 @@ from guilded.ext import commands
 from tools.dataIO import fileIO
 
 def is_dm_check(ctx):
-	guild = ctx.guild
-	if guild:
+	server = ctx.server
+	if server:
 		return False
 	else:
 		return True


### PR DESCRIPTION
Updated guilded.py requirement to 1.8.0: anything lower than that will have some routes (message reactions) stop working.
Removed `# asyncpg` from requirements, we all know that's not coming now lol.

Changed server caching; it is now possible to fetch every server at once.

Renamed all mentions of guild to server. *This does not include database entries, file names, or anything in the website.*
The reason for this is simple: `guild` is only there for compatibility with `discord.py`. Guilded API uses `server` while Discord API uses `guild`. shayy has mentioned that the `.guild` method may be discontinued in the future.